### PR TITLE
Symfony 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         "sulu/web-twig": "^2.5"
     },
     "require-dev": {
-        "dantleech/phpcr-migrations-bundle": "^1.3",
         "jackalope/jackalope-doctrine-dbal": "^1.3.2",
-        "phpstan/extension-installer": "^1.2",
-        "phpstan/phpstan": "^1.9",
-        "phpstan/phpstan-symfony": "^1.2",
-        "symplify/easy-coding-standard": "^11.1"
+        "phpcr/phpcr-migrations-bundle": "^1.3",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-symfony": "^2.0",
+        "symplify/easy-coding-standard": "^12.5"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
         "php": "^8.0",
         "pixeldev/protocol-stream": "^1.0",
         "sulu/sulu": "^2.5",
-        "symfony/dependency-injection": "^5.0 || ^6.0",
-        "symfony/http-kernel": "^5.0 || ^6.0",
+        "symfony/dependency-injection": "^5.0 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.0 || ^6.0 || ^7.0",
         "sulu/web-twig": "^2.5"
     },
     "require-dev": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         return new TreeBuilder('pixel_blockbundle');
     }


### PR DESCRIPTION
This pull request includes updates to dependencies and code improvements for type hinting. The most important changes are the updates to the `composer.json` file to support newer versions of dependencies and the addition of a return type hint in the `Configuration` class.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L9-R19): Updated `symfony/dependency-injection` and `symfony/http-kernel` to support version 7.0. Updated development dependencies to newer versions, including `phpstan/extension-installer`, `phpstan/phpstan`, `phpstan/phpstan-symfony`, and `symplify/easy-coding-standard`.

Code improvements:

* [`src/DependencyInjection/Configuration.php`](diffhunk://#diff-ebe00144d6cecb5ca8a2860883e01147f42bbed2b12a3a7f44915908a4829faaL10-R10): Added a return type hint `TreeBuilder` to the `getConfigTreeBuilder` method.